### PR TITLE
AC-5: Add Assessment Matrix API handlers with tenant filtering

### DIFF
--- a/lambda-deploy.sh
+++ b/lambda-deploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+FUNCTION_NAME="AgileCheckupApi"
+REGION="us-east-1"
+
+echo "Building Lambda package..."
+mvn clean package
+
+echo "Deploying to AWS Lambda..."
+aws lambda update-function-code \
+    --function-name $FUNCTION_NAME \
+    --zip-file fileb://target/agilecheckup-api-1.0-SNAPSHOT.jar \
+    --region $REGION
+
+echo "Deployment completed successfully!"
+
+# Optional: Update function configuration if needed
+# aws lambda update-function-configuration \
+#     --function-name $FUNCTION_NAME \
+#     --timeout 30 \
+#     --memory-size 512 \
+#     --region $REGION


### PR DESCRIPTION
## Summary
- Add tenant filtering support to AssessmentMatrix API handlers
- Ensure proper tenant isolation in REST endpoints
- Update deployment script and comprehensive API handler tests

## Changes Made
- **AssessmentMatrixRequestHandler**: Add tenant filtering to all CRUD operations
- **Unit Tests**: Complete test coverage for API handler functionality
- **Deployment**: Updated lambda-deploy.sh script
- **Security**: Enforced tenant-based data isolation at API level

## API Endpoints
- `GET /assessmentmatrices` - List matrices with tenant filtering
- `POST /assessmentmatrices` - Create matrix with tenant validation
- `PUT /assessmentmatrices/{id}` - Update matrix with tenant validation
- `DELETE /assessmentmatrices/{id}` - Delete matrix with tenant validation
- `GET /assessmentmatrices/{id}` - Get matrix by ID with tenant filtering

## Test Coverage
- All API handler operations tested with proper tenant isolation
- Error handling and validation scenarios covered
- Integration with business logic validation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>